### PR TITLE
acceptance test using restTemplate

### DIFF
--- a/src/test/java/com/kriscfoster/controllertesting/controller/WelcomeControllerAcceptanceTest.java
+++ b/src/test/java/com/kriscfoster/controllertesting/controller/WelcomeControllerAcceptanceTest.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.http.HttpStatus.OK;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class WelcomeControllerAcceptanceTest {
@@ -28,14 +29,14 @@ class WelcomeControllerAcceptanceTest {
     @Test
     void shouldGetDefaultWelcomeMessage() throws Exception {
         ResponseEntity responseEntity = restTemplate.getForEntity(url, String.class);
-        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertEquals(OK, responseEntity.getStatusCode());
         assertEquals("Welcome Stranger!", responseEntity.getBody());
     }
 
     @Test
     void shouldGetCustomWelcomeMessage() throws Exception {
         ResponseEntity responseEntity = restTemplate.getForEntity(url + "?name=John", String.class);
-        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertEquals(OK, responseEntity.getStatusCode());
         assertEquals("Welcome John!", responseEntity.getBody());
     }
 }

--- a/src/test/java/com/kriscfoster/controllertesting/controller/WelcomeControllerAcceptanceTest.java
+++ b/src/test/java/com/kriscfoster/controllertesting/controller/WelcomeControllerAcceptanceTest.java
@@ -1,37 +1,41 @@
 package com.kriscfoster.controllertesting.controller;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class WelcomeControllerAcceptanceTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+    @LocalServerPort
+    int randomServerPort;
+
+    private RestTemplate restTemplate;
+    private String url;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = new RestTemplate();
+        url = "http://localhost:" + randomServerPort + "/welcome";
+    }
 
     @Test
     void shouldGetDefaultWelcomeMessage() throws Exception {
-        mockMvc.perform(get("/welcome"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(content().string(equalTo("Welcome Stranger!")));
+        ResponseEntity responseEntity = restTemplate.getForEntity(url, String.class);
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertEquals("Welcome Stranger!", responseEntity.getBody());
     }
 
     @Test
     void shouldGetCustomWelcomeMessage() throws Exception {
-        mockMvc.perform(get("/welcome?name=John"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(content().string(equalTo("Welcome John!")));
+        ResponseEntity responseEntity = restTemplate.getForEntity(url + "?name=John", String.class);
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertEquals("Welcome John!", responseEntity.getBody());
     }
 }

--- a/src/test/java/com/kriscfoster/controllertesting/controller/WelcomeControllerAcceptanceTest.java
+++ b/src/test/java/com/kriscfoster/controllertesting/controller/WelcomeControllerAcceptanceTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 


### PR DESCRIPTION
- makes sense to use restTemplate for acceptance test instead of mockMvc because it better represents actual user usage